### PR TITLE
Run make build and test commands without CGO

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,15 @@
 ARG GO_VERSION=1.13
 
 FROM golang:${GO_VERSION} as builder
-WORKDIR /webhooks
+WORKDIR /app
 COPY . ./
 RUN make install
 RUN make test
 RUN make build
 
 FROM alpine:latest
-RUN apk --no-cache add ca-certificates
-RUN mkdir -p /app
+RUN apk --no-cache add ca-certificates bash
 WORKDIR /app
-COPY --from=builder /webhooks/build/chatstatz-webhooks .
+COPY --from=builder /app/build/chatstatz-webhooks .
 ENTRYPOINT [ "./chatstatz-webhooks" ]
 CMD [ "--help" ]

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ install:
 
 build:
 	rm -rf build/ && \
-	CGO_ENABLED=1 GOOS=linux go build -i -v -ldflags "-w -s -X main.version=${RELEASE_VERSION}" -o build/chatstatz-webhooks ./cmd/webhooks
+	CGO_ENABLED=0 GOOS=linux go build -i -v -ldflags "-w -s -X main.version=${RELEASE_VERSION}" -o build/chatstatz-webhooks ./cmd/webhooks
 
 test:
-	CGO_ENABLED=1 go test -race -covermode=atomic ./...
+	CGO_ENABLED=0 go test -covermode=atomic ./...

--- a/README.md
+++ b/README.md
@@ -31,12 +31,11 @@ Below are all expected variables and their default values.
 For continuous integration (CI) this project uses [GitHub Actions](https://github.com/chatstatz/webhooks/actions).
 The build pipeline will run tests and publish Docker images to [GCR](https://cloud.google.com/container-registry/).
 
-### Make Commands
+### Running Locally
 
-```txt
-make install      Install dependencies
-make test         Run tests
-make build        Build chatstatz-webhooks server
+```bash
+docker build --no-cache -t chatstatz-webhooks .
+docker run --rm -p 8080:8080 chatstatz-webhooks
 ```
 
 ## License


### PR DESCRIPTION
Disabling CGO while running "go build" causes Go to rebuild all
internal packages. Thus, the user that the command is run as must
have the ablitity to write to the directory where these packages
reside. In most cases, a typical user will not have perssions to
do this. As such, a error similar to the following will display:

go build net: open /usr/local/go/pkg/linux_amd64/net.a: permission denied

In our case we can avoid this by always compiling our application
using a Docker image which has root access to the necessary folders.